### PR TITLE
Added UTF-8 encoding to output file

### DIFF
--- a/checkpwnedemails.py
+++ b/checkpwnedemails.py
@@ -179,7 +179,7 @@ def write_results_to_file(filename, results, opts):
 		filename = filename[:filename.rfind('.')]
 
 	for res, f in zip(results, files):
-		outfile = open(filename + f, 'w')
+		outfile = open(filename + f, 'w', encoding='utf-8')
 
 		outfile.write(file_headers[f] + '\n')
 

--- a/checkpwnedemails.py
+++ b/checkpwnedemails.py
@@ -163,7 +163,7 @@ def write_results_to_file(filename, results, opts):
 	files = []
 
 	file_headers = {
-			BREACHESTXT: "Email Address\tIs Pwned\tPwn Count\tDomain\tName\tTitle\tData Classes\tLogo Type\tBreach Date\tAdded Date\tIs Verified\tDescription",
+			BREACHESTXT: "Email Address\tIs Pwned\tName\tTitle\tDomain\tBreach Date\tAdded Date\tModified Date\tPwn Count\tDescription\tLogo Path\tData Classes\tIs Verified\tIs Fabricated\tIs Sensitive\tIs Retired\tIs SpamList",
 			PASTESTXT:   "Email Address\tIs Pwned\tDate\tSource\tEmail Count\tID\tTitle",
 	}
 


### PR DESCRIPTION
When results were being written to file and the description had utf-8 characters, the following error was given:
UnicodeEncodeError: 'charmap' codec can't encode character '\u029e' in position 3790: character maps to <undefined>

Adding the utf-8 encoding to the output fixes this.